### PR TITLE
#170486294: Add Service Worker Update Notification

### DIFF
--- a/.docs.md
+++ b/.docs.md
@@ -2,3 +2,4 @@ z-indices:
   project flip -> 1
   tooltip -> 2
   handicap -> 2
+  sw-notification -> 3

--- a/src/helpers/swNotifications.js
+++ b/src/helpers/swNotifications.js
@@ -1,0 +1,31 @@
+const displayNotificationPage = () => {
+  // Create elements
+  const swNotification = document.createElement('div');
+  const swNotificationText = document.createElement('span');
+  const swRefreshBtn = document.createElement('button');
+
+  // Edit notification
+  swNotification.appendChild(swNotificationText);
+  swNotification.appendChild(swRefreshBtn);
+  swNotification.id = 'sw-notification';
+
+  // Edit notification text
+  swNotificationText.innerText = 'This web page has some new content. Refresh page to use fresh content.';
+  swNotificationText.id = 'sw-notification-text';
+
+  // Edit notification button
+  swRefreshBtn.innerText = 'Refresh';
+  swRefreshBtn.id = 'sw-refresh-btn';
+  swRefreshBtn.tabIndex = 1;
+  swRefreshBtn.setAttribute('aria-label', 'Page has stale content. Refresh page to update content');
+  swRefreshBtn.addEventListener('click', () => {
+    window.location.reload();
+  });
+
+  // Add notification to page
+  const root = document.getElementById('root');
+  root.appendChild(swNotification);
+  swRefreshBtn.focus();
+};
+
+export default displayNotificationPage;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import './static/global';
 import App from './App';
 import store from './store';
+import displayNotificationPage from './helpers/swNotifications';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -15,6 +16,12 @@ if ('serviceWorker' in navigator) {
       .catch((registrationError) => {
         console.log('SW registration failed: ', registrationError);
       });
+
+    navigator.serviceWorker.controller.onstatechange = (e) => {
+      if (e.target.state === 'redundant') {
+        displayNotificationPage();
+      }
+    };
   });
 }
 

--- a/src/static/global.scss
+++ b/src/static/global.scss
@@ -23,3 +23,42 @@ html {
 .ck .ck-editor__nested-editable.ck-editor__nested-editable_focused, .ck .ck-editor__nested-editable:focus {
   color: black;
 }
+
+#sw-notification {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 90%;
+  min-height: 60px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  background-color: #e5e5e5;
+  color: #000000;
+  box-shadow: 1px 3px 20px 1px #a5a5a5;
+  padding: 0 5%;
+  animation: show-notification 500ms;
+  z-index: 3;
+}
+
+@keyframes show-notification {
+  0% { top: -300px }
+  100% { top: 0 }
+}
+
+#sw-notification-text {
+  font-size: 0.8em;
+}
+
+#sw-refresh-btn {
+  background-color: #FFFFFF;
+  border: none;
+  min-width: 100px;
+  height: 45px;
+  font-size: 0.6em;
+}
+
+#sw-refresh-btn:hover,
+#sw-refresh-btn:focus {
+  cursor: pointer;
+}


### PR DESCRIPTION
#### What does this PR do?

This PR adds an update notification to the service worker to inform the user of stale content and the need to reload the page

#### Description of Task to be completed?

- [x] Create the notification
- [x] Hook the notification display up to the service worker `onstatechange` event
- [x] Bind the page-reload command to the button click

#### How should this be manually tested?

- Build the app and serve the app in production mode
- Load the homepage in the browser over ngrok
- Reload the homepage to register the new service worker
- Make changes to any part of the view and rebuild the app
- Rebuild and serve the application in production mode again
- You should see the service worker notification pop up after a while

#### What are the relevant pivotal tracker stories?

#170486294

#### Any background context you want to add?

This feature is necessary to enable users to know when the page needs to refresh.
